### PR TITLE
Make sure gcc specific options are only used with gcc (and compatible)

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -36,7 +36,7 @@ class ZlibConan(ConanFile):
             with tools.chdir("_build"):
                 if not tools.os_info.is_windows:
                     env_build = AutoToolsBuildEnvironment(self)
-                    if self.settings.arch == "x86" or self.settings.arch == "x86_64":
+                    if self.settings.arch in {"x86", "x86_64"} and self.settings.compiler in {"apple-clang", "clang", "gcc"}:
                         env_build.flags.append('-mstackrealign')
                     
                     env_build.fpic = True


### PR DESCRIPTION
Fixes compilation on Solaris with default sun-cc compiler