### PR TITLE
Patch out unistd.h inclusion on MSVC builds

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -29,6 +29,9 @@ class ZlibConan(ConanFile):
         files.rmdir("%s/contrib" % self.ZIP_FOLDER_NAME)
         if self.settings.os != "Windows":
             self.run("chmod +x ./%s/configure" % self.ZIP_FOLDER_NAME)
+        elif self.settings.compiler == "Visual Studio":
+            tools.replace_in_file("%s/zconf.h.cmakein" % self.ZIP_FOLDER_NAME, "#    include <unistd.h>", "// no unistd.h on windows")
+            tools.replace_in_file("%s/zconf.h.in" % self.ZIP_FOLDER_NAME, "#    include <unistd.h>", "// no unistd.h on windows")
             
     def build(self):
         with tools.chdir(self.ZIP_FOLDER_NAME):


### PR DESCRIPTION
MSVC does not have unistd.h, but zlib still tries to include it if some other library defines `_LARGEFILE64_SOURCE`. This pull request removes the include directives. Since `_LARGEFILE64_SOURCE` has not effect on that platform, so this should not lead to dysfunctional builds. (And does not for my test case at least.)